### PR TITLE
feat: add graphql-tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ app.register(mercuriusFederationPlugin, {
 
 #### options
 Uses the same [options](https://mercurius.dev/#/docs/api/options?id=plugin-options) of `mercurius` but
-it requires a `string` or `DocumentNode` for `schema` attribute. 
+it requires a `string`, `DocumentNode` or an Array of `DocumentNode` for `schema` attribute. 
 
 ### buildFederationSchema
 
@@ -113,6 +113,6 @@ Create a schema object that can be used in a federated environment
 
 `(schema,  opts) => GraphQLSchema`
 
-- `schema` string | DocumentNode: the source schema
+- `schema` string | DocumentNode | Array<DocumentNode>: the source schema
 - `opts` object:
   - `isGateway` boolean: If enabled create a schema compatible with the `gateway`, Default 'false'

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ app.register(mercuriusFederationPlugin, {
 
 #### options
 Uses the same [options](https://mercurius.dev/#/docs/api/options?id=plugin-options) of `mercurius` but
-it requires a `string` for `schema` attribute. 
+it requires a `string` or `DocumentNode` for `schema` attribute. 
 
 ### buildFederationSchema
 
@@ -113,6 +113,6 @@ Create a schema object that can be used in a federated environment
 
 `(schema,  opts) => GraphQLSchema`
 
-- `schema` string: the source schema
+- `schema` string | DocumentNode: the source schema
 - `opts` object:
   - `isGateway` boolean: If enabled create a schema compatible with the `gateway`, Default 'false'

--- a/examples/withGraphQLTag.js
+++ b/examples/withGraphQLTag.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const Fastify = require('fastify')
+const mercurius = require('mercurius')
+
+const { buildFederationSchema } = require('../')
+
+const users = {
+  1: {
+    id: '1',
+    name: 'John',
+    username: '@john'
+  },
+  2: {
+    id: '2',
+    name: 'Jane',
+    username: '@jane'
+  }
+}
+
+const app = Fastify()
+const gql = require('graphql-tag')
+const schema = gql`
+  extend type Query {
+    me: User
+  }
+
+  type User @key(fields: "id") {
+    id: ID!
+    name: String
+    username: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    me: () => {
+      return users['1']
+    }
+  },
+  User: {
+    __resolveReference: source => {
+      return users[source.id]
+    }
+  }
+}
+
+app.register(mercurius, {
+  schema: buildFederationSchema(schema),
+  resolvers,
+  graphiql: true
+})
+
+app.get('/', async function () {
+  const query = '{ _service { sdl } }'
+  return app.graphql(query)
+})
+
+app.listen({ port: 3000 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ export interface buildFederationSchemaOptions {
 }
 
 export type MercuriusFederationOptions = Omit<MercuriusOptions, 'schema'> & {
-  schema: string | DocumentNode
+  schema: string | DocumentNode | Array<DocumentNode>
 }
 
 export declare const mercuriusFederationPlugin: (
@@ -22,6 +22,6 @@ export declare const mercuriusFederationPlugin: (
  * Builds schema with support for federation mode.
  */
 export declare const buildFederationSchema: (
-  schema: string | DocumentNode,
+  schema: string | DocumentNode | Array<DocumentNode>,
   opts?: buildFederationSchemaOptions
 ) => GraphQLSchema

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,16 @@
 import { GraphQLSchema } from 'graphql'
 import { FastifyInstance } from 'fastify'
 import { MercuriusOptions } from 'mercurius'
+import {
+  DocumentNode
+} from 'graphql/language/ast';
 
 export interface buildFederationSchemaOptions {
   isGateway?: boolean
 }
 
 export type MercuriusFederationOptions = Omit<MercuriusOptions, 'schema'> & {
-  schema: string
+  schema: string | DocumentNode
 }
 
 export declare const mercuriusFederationPlugin: (
@@ -19,6 +22,6 @@ export declare const mercuriusFederationPlugin: (
  * Builds schema with support for federation mode.
  */
 export declare const buildFederationSchema: (
-  schema: string,
+  schema: string | DocumentNode,
   opts?: buildFederationSchemaOptions
 ) => GraphQLSchema

--- a/lib/federation.js
+++ b/lib/federation.js
@@ -39,6 +39,7 @@ const {
 } = require('graphql')
 const { validateSDL } = require('graphql/validation/validate')
 const compositionRules = require('./compositionRules')
+const mergeDocumentNode = require('./mergeDocumentNode')
 
 const {
   MER_ERR_GQL_INVALID_SCHEMA,
@@ -288,6 +289,12 @@ function buildGatewaySchemaDirectives (schema) {
 }
 
 function buildFederationSchema (schema, { isGateway } = {}) {
+  if (Array.isArray(schema)) {
+    schema = mergeDocumentNode(schema)
+  } else if (typeof schema === 'object') {
+    schema = mergeDocumentNode([schema])
+  }
+
   let federationSchema = new GraphQLSchema({
     query: undefined
   })

--- a/lib/federation.js
+++ b/lib/federation.js
@@ -39,6 +39,7 @@ const {
 } = require('graphql')
 const { validateSDL } = require('graphql/validation/validate')
 const compositionRules = require('./compositionRules')
+
 const {
   MER_ERR_GQL_INVALID_SCHEMA,
   MER_ERR_GQL_FEDERATION_INVALID_SCHEMA,
@@ -243,7 +244,7 @@ function addServiceResolver (schema, originalSchemaSDL) {
   const queryFields = query.getFields()
   queryFields._service = {
     ...queryFields._service,
-    resolve: () => ({ sdl: originalSchemaSDL })
+    resolve: () => ({ sdl: typeof originalSchemaSDL === 'string' ? originalSchemaSDL : originalSchemaSDL.loc.source.body })
   }
 
   return schema
@@ -297,7 +298,7 @@ function buildFederationSchema (schema, { isGateway } = {}) {
     { assumeValidSDL: true }
   )
 
-  const parsedOriginalSchema = parse(schema)
+  const parsedOriginalSchema = typeof schema === 'string' ? parse(schema) : schema
   const { typeStubs, extensions, definitions } = getStubTypes(
     parsedOriginalSchema.definitions,
     isGateway

--- a/lib/mergeDocumentNode.js
+++ b/lib/mergeDocumentNode.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports = function (nodes) {
+  const schema = {
+    kind: 'Document',
+    definitions: [],
+    loc: {
+      source: {
+        body: ''
+      }
+    }
+  }
+
+  nodes.forEach(s => {
+    schema.definitions = [...schema.definitions, ...s.definitions]
+    schema.loc.source.body = `${schema.loc.source.body}${s.loc.source.body}`
+  })
+
+  return schema
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "@typescript-eslint/parser": "^5.42.0",
     "fastify": "^4.9.2",
+    "graphql-tag": "^2.12.6",
     "graphql-ws": "^5.11.2",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",

--- a/tap-snapshots/test/federationWithGql.js.test.cjs
+++ b/tap-snapshots/test/federationWithGql.js.test.cjs
@@ -1,0 +1,46 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports['test/federationWithGql.js TAP buildFederationSchema function adds stub types > must match snapshot 1'] = `
+directive @external on FIELD_DEFINITION
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+
+directive @extends on OBJECT | INTERFACE
+
+directive @customdir on FIELD_DEFINITION
+
+scalar _Any
+
+scalar _FieldSet
+
+type _Service {
+  sdl: String
+}
+
+type Query {
+  me: User
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+}
+
+type Product {
+  sku: String
+}
+
+type User {
+  id: ID!
+  name: String
+  username: String
+}
+
+union _Entity = Product | User
+`

--- a/test/federationWithGql.js
+++ b/test/federationWithGql.js
@@ -1,0 +1,1197 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const { printSchema } = require('graphql')
+const WebSocket = require('ws')
+const mq = require('mqemitter')
+const mercurius = require('mercurius')
+const gql = require('graphql-tag')
+const buildFederationSchema = require('../lib/federation')
+
+test('federation support using schema from buildFederationSchema', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    extend type Mutation {
+      add(a: Int, b: Int): Int
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+  const resolvers = {
+    Query: {
+      me: () => ({
+        id: '1',
+        name: 'John',
+        username: '@john'
+      })
+    },
+    Mutation: {
+      add: (_, { a, b }) => a + b
+    },
+    User: {
+      __resolveReference: object => {
+        return {
+          id: object.id,
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  let query = '{ _service { sdl } }'
+  let res = await app.inject({ method: 'GET', url: `/graphql?query=${query}` })
+
+  t.same(JSON.parse(res.body), { data: { _service: { sdl: schema } } })
+
+  query = '{ me { id name username } }'
+  res = await app.inject({ method: 'GET', url: `/graphql?query=${query}` })
+  t.same(JSON.parse(res.body), {
+    data: { me: { id: '1', name: 'John', username: '@john' } }
+  })
+
+  query = 'mutation { add(a: 11 b: 19) }'
+  res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  t.same(JSON.parse(res.body), { data: { add: 30 } })
+})
+
+test('a normal schema can be run in federated mode', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = '{ _service { sdl } }'
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _service: {
+        sdl: schema
+      }
+    }
+  })
+})
+
+test('a schema can be run in federated mode when Query is not defined', async t => {
+  const app = Fastify()
+  const schema = `
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    User: {
+      __resolveReference: object => {
+        return {
+          id: object.id,
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = '{ _service { sdl } }'
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _service: {
+        sdl: schema
+      }
+    }
+  })
+})
+
+test('entities resolver returns correct value', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    },
+    User: {
+      __resolveReference: reference => {
+        return {
+          id: reference.id,
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "User", id: "1"}]) {
+      __typename
+      ... on User {
+        id
+        username
+        name
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [
+        {
+          __typename: 'User',
+          id: '1',
+          username: '@john',
+          name: 'John'
+        }
+      ]
+    }
+  })
+})
+
+test('entities resolver returns correct value with async resolver', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    },
+    User: {
+      __resolveReference: reference => {
+        return Promise.resolve({
+          id: reference.id,
+          name: 'John',
+          username: '@john'
+        })
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "User", id: "1"}]) {
+      __typename
+      ... on User {
+        id
+        username
+        name
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [
+        {
+          __typename: 'User',
+          id: '1',
+          username: '@john',
+          name: 'John'
+        }
+      ]
+    }
+  })
+})
+
+test('entities resolver returns user default resolver if resolveReference is not set', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "User", id: "1"}]) {
+      __typename
+      ... on User {
+        id
+        username
+        name
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [
+        {
+          __typename: 'User',
+          id: '1',
+          username: null,
+          name: null
+        }
+      ]
+    }
+  })
+})
+
+test('entities resolver throws an error if reference type name not in schema', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "Account", id: "1"}]) {
+      __typename
+      ... on User {
+        id
+        username
+        name
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.equal(
+    JSON.parse(res.body).errors[0].message,
+    'The _entities resolver tried to load an entity for type "Account", but no object type of that name was found in the schema'
+  )
+})
+
+test('buildFederationSchema function adds stub types', async t => {
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+
+    extend type Product @key(fields: "sku") {
+      sku: String
+    }
+
+    directive @customdir on FIELD_DEFINITION
+  `
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  t.matchSnapshot(printSchema(federationSchema))
+})
+
+test('buildFederationSchema works correctly with multiple type extensions', async t => {
+  const schema = `
+    extend type Query {
+      topPosts: [Post]
+    }
+
+    type Post @key(fields: "id") {
+      id: ID!
+      title: String
+      content: String
+      author: User
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post]
+    }
+
+    extend type User @key(fields: "id") {
+      other: String
+    }
+  `
+  try {
+    buildFederationSchema(gql(schema))
+    t.pass('schema built without errors')
+  } catch (err) {
+    t.fail('it should not throw errors', err)
+  }
+})
+
+test('buildFederationSchema ignores UniqueDirectivesPerLocationRule when validating', async t => {
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+
+    extend type Query {
+      topPosts: [Post]
+    }
+
+    type Post @key(fields: "id") {
+      id: ID!
+      title: String @upper
+      content: String
+      author: User
+    }
+
+    directive @upper on FIELD_DEFINITION
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post]
+    }
+
+    extend type User @key(fields: "id") {
+      other: String @upper
+    }
+  `
+  try {
+    buildFederationSchema(gql(schema))
+    t.pass('schema built without errors')
+  } catch (err) {
+    t.fail('it should not throw errors', err)
+  }
+})
+
+test('buildFederationSchema still validate schema for errors (1 error)', async t => {
+  const schema = `
+    extend type Query {
+      topPosts: [Post]
+    }
+
+    type Post @key(fields: "id") {
+      id: ID!
+      title: String
+      content: String
+      author: User
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post]
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+    }
+  `
+  try {
+    buildFederationSchema(gql(schema))
+    t.fail('it should throw validation error')
+  } catch (err) {
+    // expected error: Field "User.id" can only be defined once.
+    t.pass('it should throw error')
+  }
+})
+
+test('buildFederationSchema still validate schema for errors (multiple error)', async t => {
+  const schema = `
+    extend type Query {
+      topPosts: [Post]
+    }
+
+    type Post @key(fields: "id") {
+      id: ID!
+      title: String
+      content: String
+      author: User
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post]
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      activity: [Actions]
+    }
+  `
+  try {
+    buildFederationSchema(gql(schema))
+    t.fail('it should throw validation error')
+  } catch (err) {
+    // expected errors:
+    // Field "User.id" can only be defined once.
+    // Unknown type "Actions"
+    t.ok(err.errors)
+    t.equal(err.errors.length, 2)
+    t.pass('it should throw error')
+  }
+})
+
+test('mutation works with federation support', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+
+    extend type Mutation {
+      add(a: Int, b: Int): Int
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    },
+    Mutation: {
+      add: (root, { a, b }) => {
+        return a + b
+      }
+    },
+    User: {
+      __resolveReference: object => {
+        return {
+          id: object.id,
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = 'mutation { add(a: 11 b: 19) }'
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: {
+      query
+    }
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      add: 30
+    }
+  })
+})
+
+test('subscription server sends update to subscriptions', t => {
+  const app = Fastify()
+  t.teardown(() => app.close())
+
+  const sendTestQuery = () => {
+    app.inject(
+      {
+        method: 'POST',
+        url: '/graphql',
+        body: {
+          query: `
+          query {
+            notifications {
+              id
+              message
+            }
+          }
+        `
+        }
+      },
+      () => {
+        sendTestMutation()
+      }
+    )
+  }
+
+  const sendTestMutation = () => {
+    app.inject(
+      {
+        method: 'POST',
+        url: '/graphql',
+        body: {
+          query: `
+          mutation {
+            addNotification(message: "Hello World") {
+              id
+            }
+          }
+        `
+        }
+      },
+      () => {}
+    )
+  }
+
+  const emitter = mq()
+  const schema = `
+    type Notification @key(fields: "id") {
+      id: ID!
+      message: String
+    }
+
+    extend type Query {
+      notifications: [Notification]
+    }
+
+    extend type Mutation {
+      addNotification(message: String): Notification
+    }
+
+    extend type Subscription {
+      notificationAdded: Notification
+    }
+  `
+
+  let idCount = 1
+  const notifications = [
+    {
+      id: idCount,
+      message: 'Notification message'
+    }
+  ]
+
+  const resolvers = {
+    Query: {
+      notifications: () => notifications
+    },
+    Mutation: {
+      addNotification: async (_, { message }) => {
+        const id = idCount++
+        const notification = {
+          id,
+          message
+        }
+        notifications.push(notification)
+        await emitter.emit({
+          topic: 'NOTIFICATION_ADDED',
+          payload: {
+            notificationAdded: notification
+          }
+        })
+
+        return notification
+      }
+    },
+    Subscription: {
+      notificationAdded: {
+        subscribe: (root, args, { pubsub }) =>
+          pubsub.subscribe('NOTIFICATION_ADDED')
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers,
+    subscription: {
+      emitter
+    }
+  })
+
+  app.listen({ port: 0 }, err => {
+    t.error(err)
+
+    const ws = new WebSocket(
+      'ws://localhost:' + app.server.address().port + '/graphql',
+      'graphql-ws'
+    )
+    const client = WebSocket.createWebSocketStream(ws, {
+      encoding: 'utf8',
+      objectMode: true
+    })
+    t.teardown(client.destroy.bind(client))
+    client.setEncoding('utf8')
+
+    client.write(
+      JSON.stringify({
+        type: 'connection_init'
+      })
+    )
+
+    client.write(
+      JSON.stringify({
+        id: 1,
+        type: 'start',
+        payload: {
+          query: `
+          subscription {
+            notificationAdded {
+              id
+              message
+            }
+          }
+        `
+        }
+      })
+    )
+
+    client.write(
+      JSON.stringify({
+        id: 2,
+        type: 'start',
+        payload: {
+          query: `
+          subscription {
+            notificationAdded {
+              id
+              message
+            }
+          }
+        `
+        }
+      })
+    )
+
+    client.write(
+      JSON.stringify({
+        id: 2,
+        type: 'stop'
+      })
+    )
+
+    client.on('data', chunk => {
+      const data = JSON.parse(chunk)
+
+      if (data.id === 1 && data.type === 'data') {
+        t.equal(
+          chunk,
+          JSON.stringify({
+            type: 'data',
+            id: 1,
+            payload: {
+              data: {
+                notificationAdded: {
+                  id: '1',
+                  message: 'Hello World'
+                }
+              }
+            }
+          })
+        )
+
+        client.end()
+        t.end()
+      } else if (data.id === 2 && data.type === 'complete') {
+        sendTestQuery()
+      }
+    })
+  })
+})
+
+test('federation supports loader for __resolveReference function', async t => {
+  const app = Fastify()
+  const users = {
+    1: {
+      id: 1,
+      name: 'John',
+      username: '@john'
+    },
+    2: {
+      id: 2,
+      name: 'Jane',
+      username: '@jane'
+    }
+  }
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return users['1']
+      }
+    }
+  }
+
+  const loaders = {
+    User: {
+      async __resolveReference (queries) {
+        t.same(queries, [
+          {
+            obj: {
+              __typename: 'User',
+              id: '1'
+            },
+            params: {}
+          },
+          {
+            obj: {
+              __typename: 'User',
+              id: '2'
+            },
+            params: {}
+          }
+        ])
+        return queries.map(({ obj }) => users[obj.id])
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers,
+    loaders
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "User", id: "1" }, { __typename: "User", id: "2" }, { __typename: "User", id: "1" }]) {
+      ... on User {
+        id
+        username
+        name
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    body: {
+      query
+    }
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [
+        {
+          id: '1',
+          username: '@john',
+          name: 'John'
+        },
+        {
+          id: '2',
+          username: '@jane',
+          name: 'Jane'
+        },
+        {
+          id: '1',
+          username: '@john',
+          name: 'John'
+        }
+      ]
+    }
+  })
+})
+
+test('federation schema is built correctly with type extension', async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      topPosts: [Post]
+    }
+
+    type Post @key(fields: "id") {
+      id: ID!
+      title: String
+      content: String
+      author: User
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post]
+    }
+  `
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema
+  })
+
+  await app.ready()
+
+  const query = '{ topPosts { id author { id posts { id } } } }'
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      topPosts: null
+    }
+  })
+})
+
+test("basic federation support with 'schema' in the schema", async t => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+
+    schema {
+      query: Query
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => {
+        return {
+          id: '1',
+          name: 'John',
+          username: '@john'
+        }
+      }
+    },
+    User: {
+      __resolveReference: object => {
+        return {
+          id: object.id,
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = '{ _service { sdl } }'
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _service: {
+        sdl: schema
+      }
+    }
+  })
+})
+
+test('buildFederationSchema remove some directive in isGateway mode', async t => {
+  const schema = `
+    directive @custom(input: ID) on OBJECT | FIELD_DEFINITION
+    
+    directive @custom(input: ID) on OBJECT | FIELD_DEFINITION
+  
+    extend type Query {
+      topPosts: [Post]
+    }
+
+    type Post @key(fields: "id") {
+      id: ID!
+      title: String
+      content: String
+      author: User
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post]
+    }
+
+    extend type User @key(fields: "id") {
+      other: String
+    }
+  `
+  try {
+    const resultGateway = buildFederationSchema(gql(schema), { isGateway: true })
+
+    const printedSchema = printSchema(resultGateway)
+
+    t.notOk(printedSchema.includes('directive @external on FIELD_DEFINITION'))
+    t.notOk(
+      printedSchema.includes(
+        'directive @provides(fields: _FieldSet!) on FIELD_DEFINITION'
+      )
+    )
+    t.notOk(
+      printedSchema.includes(
+        'directive @key(fields: _FieldSet!) on OBJECT | INTERFACE'
+      )
+    )
+    t.notOk(printedSchema.includes('directive @extends on OBJECT | INTERFACE'))
+    t.notOk(printedSchema.includes('type _Service'))
+    t.notOk(
+      printedSchema.includes('_entities(representations: [_Any!]!): [_Entity]!')
+    )
+    t.notOk(printedSchema.includes('union _Entity = User | Post'))
+    t.ok(
+      printedSchema.includes(
+        'directive @requires(fields: _FieldSet!) on FIELD_DEFINITION'
+      )
+    )
+  } catch (err) {
+    t.fail('it should not throw errors', err)
+  }
+})
+
+test('buildFederationSchema thrown an error on duplicated directive that with different signature in isGateway mode', async t => {
+  const schema = `
+    directive @custom(input: ID) on OBJECT | FIELD_DEFINITION
+    
+    directive @custom(input: String) on OBJECT | FIELD_DEFINITION
+  
+    extend type Query {
+      topPosts: [Post]
+    }
+
+    type Post @key(fields: "id") {
+      id: ID!
+      title: String
+      content: String
+      author: User
+    }
+
+    extend type User @key(fields: "id") {
+      id: ID! @external
+      posts: [Post]
+    }
+
+    extend type User @key(fields: "id") {
+      other: String
+    }
+  `
+  try {
+    buildFederationSchema(gql(schema), { isGateway: true })
+    t.fail('schema built without errors')
+  } catch (err) {
+    t.same(
+      err.message,
+      'Directive with a different definition but the same name "custom" already exists in the gateway schema'
+    )
+  }
+})
+
+test('buildFederationSchema with extension directive', async t => {
+  const schema = `
+    type Post @key(fields: "id") @extends {
+      id: ID!
+      title: String
+      content: String
+    }
+  `
+  try {
+    const resultGateway = buildFederationSchema(gql(schema))
+    const printedSchema = printSchema(resultGateway)
+    t.ok(printedSchema.includes('directive @extends on OBJECT | INTERFACE'))
+  } catch (err) {
+    t.fail('schema built with errors')
+  }
+})

--- a/test/federationWithMultipleGql.js
+++ b/test/federationWithMultipleGql.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const mercurius = require('mercurius')
+const gql = require('graphql-tag')
+const buildFederationSchema = require('../lib/federation')
+
+test('federation support using schema from buildFederationSchema', async t => {
+  const app = Fastify()
+  const schema1 = `
+    extend type Query {
+      me: User
+    }
+  `
+
+  const schema2 = `
+    extend type Mutation {
+      add(a: Int, b: Int): Int
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => ({
+        id: '1',
+        name: 'John',
+        username: '@john'
+      })
+    },
+    Mutation: {
+      add: (_, { a, b }) => a + b
+    },
+    User: {
+      __resolveReference: object => {
+        return {
+          id: object.id,
+          name: 'John',
+          username: '@john'
+        }
+      }
+    }
+  }
+
+  const schema = [gql(schema1), gql(schema2)]
+
+  const federationSchema = buildFederationSchema(schema)
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  let query = '{ _service { sdl } }'
+  let res = await app.inject({ method: 'GET', url: `/graphql?query=${query}` })
+
+  t.same(JSON.parse(res.body), { data: { _service: { sdl: `${schema1}${schema2}` } } })
+
+  query = '{ me { id name username } }'
+  res = await app.inject({ method: 'GET', url: `/graphql?query=${query}` })
+  t.same(JSON.parse(res.body), {
+    data: { me: { id: '1', name: 'John', username: '@john' } }
+  })
+
+  query = 'mutation { add(a: 11 b: 19) }'
+  res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  t.same(JSON.parse(res.body), { data: { add: 30 } })
+})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,5 +1,6 @@
 import { expectType, expectError } from 'tsd'
 import Fastify from 'fastify'
+import gql from 'graphql-tag'
 import { GraphQLSchema } from 'graphql/index'
 
 import { buildFederationSchema, mercuriusFederationPlugin } from '../../index'
@@ -17,6 +18,7 @@ const schema = `
   `
 
 expectType<GraphQLSchema>(buildFederationSchema(schema))
+expectType<GraphQLSchema>(buildFederationSchema(gql(schema)))
 expectType<GraphQLSchema>(buildFederationSchema(schema, {}))
 expectType<GraphQLSchema>(buildFederationSchema(schema, { isGateway: true }))
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -17,8 +17,15 @@ const schema = `
     }
   `
 
+const schema2 = `
+    extend type Query {
+      you: User
+    }
+  `
+
 expectType<GraphQLSchema>(buildFederationSchema(schema))
 expectType<GraphQLSchema>(buildFederationSchema(gql(schema)))
+expectType<GraphQLSchema>(buildFederationSchema([gql(schema), gql(schema2)]))
 expectType<GraphQLSchema>(buildFederationSchema(schema, {}))
 expectType<GraphQLSchema>(buildFederationSchema(schema, { isGateway: true }))
 


### PR DESCRIPTION
Add support for schema generated by `graphql-tag`

Why is this an important feature?

To integrate tools that help to organise the project

(Eg.)
```
    const {loadFiles} = require('@graphql-tools/load-files')
    
    const schema = await loadFiles(
      path.resolve(__dirname, '../modules/**/*.graphql')
    )

    const resolvers = (await loadFiles(
      path.resolve(__dirname, '../modules/**/resolvers.js')
    )).reduce((acc, resolver) => {
      Object.entries(resolver).forEach(([key, value]) => {
        if(!acc[key]) {
          acc[key] = {}
        }

        acc[key] = {...acc[key], ...value}
      })

      return acc
    }, {})
```
