### PR TITLE
Feature: add support for interface resolution

### DIFF
--- a/lib/federation.js
+++ b/lib/federation.js
@@ -197,7 +197,7 @@ function resolveType (reference, context, info) {
     __typename: undefined
   }, context, info, type)
 
-  if (typeof resolveType !== 'string' && 'then' in resolveType && typeof resolveType.then === 'function') {
+  if (typeof resolveType !== 'string' && typeof resolveType.then === 'function') {
     return resolveType.then((resolvedTypename) =>
       info.schema.getType(resolvedTypename)
     )
@@ -234,7 +234,7 @@ function addEntitiesResolver (schema) {
         return representations.map(reference => {
           const type = resolveType(reference, context, info)
 
-          if (type && 'then' in type && typeof type.then === 'function') {
+          if (type && typeof type.then === 'function') {
             return type.then((resolvedType) => {
               const resolveReference = resolvedType.resolveReference
                 ? resolvedType.resolveReference
@@ -244,7 +244,7 @@ function addEntitiesResolver (schema) {
 
               const result = resolveReference(reference, {}, context, info)
 
-              if (result && 'then' in result && typeof result.then === 'function') {
+              if (result && typeof result.then === 'function') {
                 return result.then((x) =>
                   addTypeNameToResult(x, resolvedType.name))
               }

--- a/lib/federation.js
+++ b/lib/federation.js
@@ -188,9 +188,7 @@ function resolveType (reference, context, info) {
     return type
   }
 
-  const resolveTypeFn = type.resolveType
-    ? type.resolveType
-    : defaultTypeResolver
+  const resolveTypeFn = type.resolveType || defaultTypeResolver
 
   const resolveType = resolveTypeFn({
     ...reference,
@@ -236,9 +234,8 @@ function addEntitiesResolver (schema) {
 
           if (type && typeof type.then === 'function') {
             return type.then((resolvedType) => {
-              const resolveReference = resolvedType.resolveReference
-                ? resolvedType.resolveReference
-                : function defaultResolveReference () {
+              const resolveReference = resolvedType.resolveReference ||
+                function defaultResolveReference () {
                   return reference
                 }
 

--- a/lib/federation.js
+++ b/lib/federation.js
@@ -34,7 +34,9 @@ const {
   isTypeDefinitionNode,
   isTypeExtensionNode,
   isObjectType,
+  isInterfaceType,
   isSpecifiedDirective,
+  defaultTypeResolver,
   GraphQLDirective
 } = require('graphql')
 const { validateSDL } = require('graphql/validation/validate')
@@ -173,6 +175,37 @@ function addTypeNameToResult (result, typename) {
   return result
 }
 
+function resolveType (reference, context, info) {
+  const { __typename } = reference
+
+  const type = info.schema.getType(__typename)
+
+  if (!type || !(isObjectType(type) || isInterfaceType(type))) {
+    throw new MER_ERR_GQL_FEDERATION_INVALID_SCHEMA(__typename)
+  }
+
+  if (!isInterfaceType(type)) {
+    return type
+  }
+
+  const resolveTypeFn = type.resolveType
+    ? type.resolveType
+    : defaultTypeResolver
+
+  const resolveType = resolveTypeFn({
+    ...reference,
+    __typename: undefined
+  }, context, info, type)
+
+  if (typeof resolveType !== 'string' && 'then' in resolveType && typeof resolveType.then === 'function') {
+    return resolveType.then((resolvedTypename) =>
+      info.schema.getType(resolvedTypename)
+    )
+  }
+
+  return info.schema.getType(resolveType)
+}
+
 function addEntitiesResolver (schema) {
   const entityTypes = Object.values(schema.getTypeMap()).filter(
     type => isObjectType(type) && typeIncludesDirective(type, 'key')
@@ -199,12 +232,25 @@ function addEntitiesResolver (schema) {
       ...queryFields._entities,
       resolve: (_source, { representations }, context, info) => {
         return representations.map(reference => {
-          const { __typename } = reference
+          const type = resolveType(reference, context, info)
 
-          const type = info.schema.getType(__typename)
+          if (type && 'then' in type && typeof type.then === 'function') {
+            return type.then((resolvedType) => {
+              const resolveReference = resolvedType.resolveReference
+                ? resolvedType.resolveReference
+                : function defaultResolveReference () {
+                  return reference
+                }
 
-          if (!type || !isObjectType(type)) {
-            throw new MER_ERR_GQL_FEDERATION_INVALID_SCHEMA(__typename)
+              const result = resolveReference(reference, {}, context, info)
+
+              if (result && 'then' in result && typeof result.then === 'function') {
+                return result.then((x) =>
+                  addTypeNameToResult(x, resolvedType.name))
+              }
+
+              return addTypeNameToResult(result, resolvedType.name)
+            })
           }
 
           const resolveReference = type.resolveReference
@@ -216,10 +262,11 @@ function addEntitiesResolver (schema) {
           const result = resolveReference(reference, {}, context, info)
 
           if (result && 'then' in result && typeof result.then === 'function') {
-            return result.then(x => addTypeNameToResult(x, __typename))
+            return result.then((x) =>
+              addTypeNameToResult(x, type.name))
           }
 
-          return addTypeNameToResult(result, __typename)
+          return addTypeNameToResult(result, type.name)
         })
       }
     }

--- a/test/federationWithGql.js
+++ b/test/federationWithGql.js
@@ -1195,3 +1195,515 @@ test('buildFederationSchema with extension directive', async t => {
     t.fail('schema built with errors')
   }
 })
+
+test('entities resolver returns correct value for interface', async (t) => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      product: Product
+    }
+    interface Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type BundleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+      productIds: [ID!]!
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      product: () => {
+        return {
+          id: '1',
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    },
+    Product: {
+      resolveType: () => {
+        return 'BundleProduct'
+      }
+    },
+    BundleProduct: {
+      __resolveReference: (reference) => {
+        return {
+          id: reference.id,
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "Product", id: "1"}]) {
+      __typename
+      ... on Product {
+        id
+        name
+      }
+      ... on BundleProduct {
+        productIds
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [{
+        __typename: 'BundleProduct',
+        id: '1',
+        name: 'bundle',
+        productIds: ['001', '002']
+      }]
+    }
+  })
+})
+
+test('entities resolver returns correct value for interface with async resolveType', async (t) => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      product: Product
+    }
+    interface Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type BundleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+      productIds: [ID!]!
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      product: () => {
+        return {
+          id: '1',
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    },
+    Product: {
+      resolveType: () => {
+        return Promise.resolve('BundleProduct')
+      }
+    },
+    BundleProduct: {
+      __resolveReference: (reference) => {
+        return {
+          id: reference.id,
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "Product", id: "1"}]) {
+      __typename
+      ... on Product {
+        id
+        name
+      }
+      ... on BundleProduct {
+        productIds
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [{
+        __typename: 'BundleProduct',
+        id: '1',
+        name: 'bundle',
+        productIds: ['001', '002']
+      }]
+    }
+  })
+})
+
+test('entities resolver returns correct value for interface with async resolveType and resolveReference', async (t) => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      product: Product
+    }
+    interface Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type BundleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+      productIds: [ID!]!
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      product: () => {
+        return {
+          id: '1',
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    },
+    Product: {
+      resolveType: () => {
+        return Promise.resolve('BundleProduct')
+      }
+    },
+    BundleProduct: {
+      __resolveReference: (reference) => {
+        return Promise.resolve({
+          id: reference.id,
+          name: 'bundle',
+          productIds: ['001', '002']
+        })
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "Product", id: "1"}]) {
+      __typename
+      ... on Product {
+        id
+        name
+      }
+      ... on BundleProduct {
+        productIds
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [{
+        __typename: 'BundleProduct',
+        id: '1',
+        name: 'bundle',
+        productIds: ['001', '002']
+      }]
+    }
+  })
+})
+
+test('entities resolver returns correct value for interface with async without definition of resolveReference', async (t) => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      product: Product
+    }
+    interface Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type BundleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+      productIds: [ID!]!
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      product: () => {
+        return {
+          id: '1',
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    },
+    Product: {
+      resolveType: () => {
+        return Promise.resolve('BundleProduct')
+      }
+    },
+    BundleProduct: {}
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "Product", id: "1"}]) {
+      __typename
+      ... on Product {
+        id
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [{
+        __typename: 'BundleProduct',
+        id: '1'
+      }]
+    }
+  })
+})
+
+test('entities resolver returns correct value for interface using isTypeOf method', async (t) => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      product: Product
+    }
+    interface Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type SingleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type BundleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+      productIds: [ID!]!
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      product: () => {
+        return {
+          __typename: 'BundleProduct',
+          id: '1',
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    },
+    SingleProduct: {
+      isTypeOf: () => {
+        return false
+      },
+      __resolveReference: (reference) => {
+        return {
+          id: reference.id,
+          name: 'single'
+        }
+      }
+    },
+    BundleProduct: {
+      isTypeOf: () => {
+        return true
+      },
+      __resolveReference: (reference) => {
+        return {
+          id: reference.id,
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "Product", id: "1"}]) {
+      __typename
+      ... on Product {
+        id
+        name
+      }
+      ... on BundleProduct {
+        productIds
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [{
+        __typename: 'BundleProduct',
+        id: '1',
+        name: 'bundle',
+        productIds: ['001', '002']
+      }]
+    }
+  })
+})
+
+test('entities resolver returns correct value for interface using isTypeOf as promise', async (t) => {
+  const app = Fastify()
+  const schema = `
+    extend type Query {
+      product: Product
+    }
+    interface Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type SingleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+    }
+    type BundleProduct implements Product @key(fields: "id") {
+      id: ID!
+      name: String!
+      productIds: [ID!]!
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      product: () => {
+        return {
+          __typename: 'BundleProduct',
+          id: '1',
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    },
+    SingleProduct: {
+      isTypeOf: () => {
+        return Promise.resolve(false)
+      },
+      __resolveReference: (reference) => {
+        return {
+          id: reference.id,
+          name: 'single'
+        }
+      }
+    },
+    BundleProduct: {
+      isTypeOf: () => {
+        return Promise.resolve(true)
+      },
+      __resolveReference: (reference) => {
+        return {
+          id: reference.id,
+          name: 'bundle',
+          productIds: ['001', '002']
+        }
+      }
+    }
+  }
+
+  const federationSchema = buildFederationSchema(gql(schema))
+
+  app.register(mercurius, {
+    schema: federationSchema,
+    resolvers
+  })
+
+  await app.ready()
+
+  const query = `
+  {
+    _entities(representations: [{ __typename: "Product", id: "1"}]) {
+      __typename
+      ... on Product {
+        id
+        name
+      }
+      ... on BundleProduct {
+        productIds
+      }
+    }
+  }
+  `
+  const res = await app.inject({
+    method: 'GET',
+    url: `/graphql?query=${query}`
+  })
+
+  t.same(JSON.parse(res.body), {
+    data: {
+      _entities: [{
+        __typename: 'BundleProduct',
+        id: '1',
+        name: 'bundle',
+        productIds: ['001', '002']
+      }]
+    }
+  })
+})


### PR DESCRIPTION
This implementation will enable the resolution of a GraphQL interface requested by the federation.

The resolution will be accessible using the entity resolution by putting as `typename` the interface as the following example

**Node schema**

```graphql
type Query {
  product: Product
}

interface Product @key(fields: "id") {
  id: ID!
  name: String!
}

type BundleProduct implements Product @key(fields: "id") {
  id: ID!
  name: String!
  productIds: [ID!]!
}
```

**Query**
```
query {
    _entities(representations: [{ __typename: "Product", id: "1"}]) {
      __typename
      ... on Product {
        id
        name
      }
      ... on BundleProduct {
        productIds
      }
    }
  }
 ```

> **Note**
> The current implementation of mercurius does not allow to define an interface without its implementations but it could be  a future improvement. Anyway it's possible to use this feature by import the [@interfaceObject](https://www.apollographql.com/docs/federation/federated-types/interfaces/) directive from Apollo Federation v2.3 