### PR TITLE
Export federationSchemaTransformer and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,97 @@ Create a schema object that can be used in a federated environment
 - `schema` string | DocumentNode | Array<DocumentNode>: the source schema
 - `opts` object:
   - `isGateway` boolean: If enabled create a schema compatible with the `gateway`, Default 'false'
+
+### federationSchemaTransformer
+
+Wraps an array of schema transformers (e.g. custom directive transformers built with `@graphql-tools/utils` `mapSchema`) so that the `resolveReference` functions defined on entity types are preserved after the transformation.
+
+When mercurius applies `schemaTransforms`, `mapSchema` internally recreates every `GraphQLObjectType` via `new GraphQLObjectType(type.toConfig())`. Because `resolveReference` is a non-standard property set at runtime by mercurius, it is **lost** during this process. `federationSchemaTransformer` takes care of copying it back onto the new type instances after every transformer runs.
+
+`(transformers: SchemaTransformer[]) => SchemaTransformer`
+
+- `transformers` Array of functions `(schema: GraphQLSchema) => GraphQLSchema`: the directive / schema transformers to apply.
+
+> **Note:** `mercuriusFederationPlugin` already wraps `schemaTransforms` with `federationSchemaTransformer` automatically. You only need to use this function when you build the federation schema yourself with `buildFederationSchema` and register it directly with `mercurius`.
+
+#### Usage with `mercuriusFederationPlugin`
+
+When using the plugin, just pass your transformers directly — the plugin handles the wrapping:
+
+```js
+const { mercuriusFederationPlugin } = require('@mercuriusjs/federation')
+
+app.register(mercuriusFederationPlugin, {
+  schema,
+  resolvers,
+  schemaTransforms: [upperDirectiveTransformer]
+})
+```
+
+#### Usage with `buildFederationSchema` and `mercurius`
+
+When registering mercurius directly with a federation schema, you must wrap transformers with `federationSchemaTransformer` to preserve `resolveReference`:
+
+```js
+const mercurius = require('mercurius')
+const { buildFederationSchema, federationSchemaTransformer } = require('@mercuriusjs/federation')
+const { MapperKind, mapSchema, getDirective } = require('@graphql-tools/utils')
+const { defaultFieldResolver } = require('graphql')
+
+// Define a directive transformer
+function upperDirectiveTransformer (schema) {
+  return mapSchema(schema, {
+    [MapperKind.FIELD]: (fieldConfig) => {
+      const upperDirective = getDirective(schema, fieldConfig, 'upper')?.[0]
+      if (upperDirective) {
+        const { resolve = defaultFieldResolver } = fieldConfig
+        fieldConfig.resolve = async function (obj, args, ctx, info) {
+          const result = await resolve(obj, args, ctx, info)
+          return typeof result === 'string' ? result.toUpperCase() : result
+        }
+        return fieldConfig
+      }
+    }
+  })
+}
+
+const schema = `
+  directive @upper on FIELD_DEFINITION
+
+  extend type Query {
+    me: User
+  }
+
+  type User @key(fields: "id") {
+    id: ID!
+    name: String @upper
+    username: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    me: () => users['1']
+  },
+  User: {
+    __resolveReference: (source) => users[source.id]
+  }
+}
+
+app.register(mercurius, {
+  schema: buildFederationSchema(schema),
+  resolvers,
+  schemaTransforms: federationSchemaTransformer([upperDirectiveTransformer])
+})
+```
+
+**Without `federationSchemaTransformer`** in this scenario, `_entities` queries will fail because `resolveReference` is lost during the schema transformation:
+
+```js
+// ⚠️ _entities queries will return null for entity fields
+app.register(mercurius, {
+  schema: buildFederationSchema(schema),
+  resolvers,
+  schemaTransforms: [upperDirectiveTransformer]
+})
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,3 +25,15 @@ export declare const buildFederationSchema: (
   schema: string | DocumentNode | Array<DocumentNode>,
   opts?: buildFederationSchemaOptions
 ) => GraphQLSchema
+
+export type SchemaTransformer = (schema: GraphQLSchema) => GraphQLSchema
+
+/**
+ * Wraps an array of schema transformers so that `resolveReference` functions
+ * (set by mercurius on entity types) are preserved after the transformation.
+ * Use this instead of passing transformers directly to `schemaTransforms`
+ * when working with federated schemas.
+ */
+export declare const federationSchemaTransformer: (
+  transformers: SchemaTransformer[]
+) => SchemaTransformer

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const buildFederationSchema = require('./lib/federation')
 const mercuriusFederationPlugin = require('./lib/plugin')
+const federationSchemaTransformer = require('./lib/transformFederatedSchema')
 
-module.exports = { mercuriusFederationPlugin, buildFederationSchema }
+module.exports = { mercuriusFederationPlugin, buildFederationSchema, federationSchemaTransformer }
 module.exports.default = mercuriusFederationPlugin

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,10 +4,12 @@ const fp = require('fastify-plugin')
 const GQL = require('mercurius')
 
 const buildFederationSchema = require('./federation')
+const federationTrasformer = require('./transformFederatedSchema')
 
 module.exports = fp(async (fastify, props) => {
   await fastify.register(GQL, {
     ...props,
-    schema: buildFederationSchema(props.schema)
+    schema: buildFederationSchema(props.schema),
+    schemaTransforms: props.schemaTransforms ? federationTrasformer(props.schemaTransforms) : undefined
   })
 })

--- a/lib/transformFederatedSchema.js
+++ b/lib/transformFederatedSchema.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { isObjectType } = require('graphql/type')
+const { mapSchema } = require('@graphql-tools/utils')
+
+const federationTrasformer = (
+  transformers
+) => {
+  return (schema) => {
+    const originalTypeMap = schema.getTypeMap()
+
+    let newSchema = mapSchema(schema, {})
+    for (const transformer of transformers) {
+      newSchema = transformer(newSchema)
+    }
+    // resolveReference is a non-standard property set by defineLoaders
+    // on each GraphQLObjectType. mapSchema/rewireTypes creates new instances via
+    // new GraphQLObjectType({...type.toConfig()}) which does not include non-standard
+    // properties. resolveReference must be copied over to the new instances.
+    for (const [typeName, newType] of Object.entries(
+      newSchema.getTypeMap()
+    )) {
+      const originalType = originalTypeMap[typeName]
+      if (
+        isObjectType(originalType) && originalType.resolveReference
+      ) {
+        newType.resolveReference = originalType.resolveReference
+      }
+    }
+    return newSchema
+  }
+}
+
+module.exports = federationTrasformer

--- a/test/custom-directives.test.js
+++ b/test/custom-directives.test.js
@@ -1,0 +1,424 @@
+'use strict'
+
+const { test } = require('node:test')
+const Fastify = require('fastify')
+const { defaultFieldResolver } = require('graphql')
+const GQL = require('mercurius')
+const {
+  MapperKind,
+  mapSchema,
+  getDirective
+} = require('@graphql-tools/utils')
+const buildFederationSchema = require('../lib/federation')
+const federationTrasformer = require('../lib/transformFederatedSchema')
+
+// --- Directive transformers ---
+
+function upperDirectiveTransformer (schema) {
+  return mapSchema(schema, {
+    [MapperKind.FIELD]: (fieldConfig) => {
+      const upperDirective = getDirective(schema, fieldConfig, 'upper')?.[0]
+      if (upperDirective) {
+        const { resolve = defaultFieldResolver } = fieldConfig
+        fieldConfig.resolve = async function (obj, args, ctx, info) {
+          const result = await resolve(obj, args, ctx, info)
+          return typeof result === 'string' ? result.toUpperCase() : result
+        }
+        return fieldConfig
+      }
+    }
+  })
+}
+
+const PHONE_REGEXP = /(?:\+?\d{2}[ -]?\d{3}[ -]?\d{5}|\d{4})/g
+const EMAIL_REGEXP = /([^\s@])+@[^\s@]+\.[^\s@]+/g
+
+function redactDirectiveTransformer (schema) {
+  return mapSchema(schema, {
+    [MapperKind.FIELD]: (fieldConfig) => {
+      const redactDirective = getDirective(schema, fieldConfig, 'redact')?.[0]
+      if (redactDirective) {
+        const { find } = redactDirective
+        const { resolve = defaultFieldResolver } = fieldConfig
+        fieldConfig.resolve = async function (obj, args, ctx, info) {
+          const value = await resolve(obj, args, ctx, info)
+          if (typeof value !== 'string') return value
+          switch (find) {
+            case 'email':
+              return value.replace(EMAIL_REGEXP, '****@*****. ***')
+            case 'phone':
+              return value.replace(PHONE_REGEXP, m => '*'.repeat(m.length))
+            default:
+              return value
+          }
+        }
+        return fieldConfig
+      }
+    }
+  })
+}
+
+// --- Non-federation tests ---
+
+test('custom directive @redact works without federation', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @redact(find: String) on FIELD_DEFINITION
+
+    type Document {
+      excerpt: String! @redact(find: "email")
+      text: String! @redact(find: "phone")
+    }
+
+    type Query {
+      documents: [Document]
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      documents: () => [
+        {
+          excerpt: 'Contact us at info@example.com for details',
+          text: 'Call us at +39 333 12345'
+        }
+      ]
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    schemaTransforms: [redactDirectiveTransformer]
+  })
+
+  await app.ready()
+
+  const query = '{ documents { excerpt text } }'
+  const res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  const body = JSON.parse(res.body)
+
+  t.assert.strictEqual(body.data.documents[0].excerpt.includes('info@example.com'), false)
+  t.assert.strictEqual(body.data.documents[0].excerpt.includes('****@*****.'), true)
+  t.assert.strictEqual(body.data.documents[0].text.includes('+39 333 12345'), false)
+})
+
+test('custom directive @upper works without federation', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+
+    type Query {
+      hello: String @upper
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      hello: () => 'world'
+    }
+  }
+
+  app.register(GQL, {
+    schema,
+    resolvers,
+    schemaTransforms: [upperDirectiveTransformer]
+  })
+
+  await app.ready()
+
+  const query = '{ hello }'
+  const res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  t.assert.deepStrictEqual(JSON.parse(res.body), { data: { hello: 'WORLD' } })
+})
+
+// --- Federation tests ---
+
+test('custom directive @upper works with federation schema and @key entity', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String @upper
+      username: String
+    }
+  `
+
+  const users = {
+    1: { id: '1', name: 'John', username: '@john' },
+    2: { id: '2', name: 'Jane', username: '@jane' }
+  }
+
+  const resolvers = {
+    Query: {
+      me: () => users['1']
+    },
+    User: {
+      __resolveReference: (source) => users[source.id]
+    }
+  }
+
+  app.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers,
+    schemaTransforms: [upperDirectiveTransformer]
+  })
+
+  await app.ready()
+
+  // Verify directive applies to the field
+  const query = '{ me { id name username } }'
+  const res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  const body = JSON.parse(res.body)
+
+  t.assert.strictEqual(body.data.me.name, 'JOHN')
+  t.assert.strictEqual(body.data.me.username, '@john')
+})
+
+test('custom directive @upper preserves _service sdl in federation', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String @upper
+      username: String
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      me: () => ({ id: '1', name: 'John', username: '@john' })
+    },
+    User: {
+      __resolveReference: (source) => ({ id: source.id, name: 'John', username: '@john' })
+    }
+  }
+
+  app.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers,
+    schemaTransforms: [upperDirectiveTransformer]
+  })
+
+  await app.ready()
+
+  const query = '{ _service { sdl } }'
+  const res = await app.inject({ method: 'GET', url: `/graphql?query=${query}` })
+  t.assert.deepStrictEqual(JSON.parse(res.body), { data: { _service: { sdl: schema } } })
+})
+
+test('custom directive @redact works with federation schema', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @redact(find: String) on FIELD_DEFINITION
+
+    extend type Query {
+      contact: Contact
+    }
+
+    type Contact @key(fields: "id") {
+      id: ID!
+      email: String @redact(find: "email")
+      phone: String @redact(find: "phone")
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      contact: () => ({
+        id: '1',
+        email: 'john@example.com',
+        phone: '+39 333 12345'
+      })
+    },
+    Contact: {
+      __resolveReference: (source) => ({
+        id: source.id,
+        email: 'john@example.com',
+        phone: '+39 333 12345'
+      })
+    }
+  }
+
+  app.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers,
+    schemaTransforms: [redactDirectiveTransformer]
+  })
+
+  await app.ready()
+
+  const query = '{ contact { id email phone } }'
+  const res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  const body = JSON.parse(res.body)
+
+  t.assert.strictEqual(body.data.contact.id, '1')
+  t.assert.strictEqual(body.data.contact.email.includes('john@example.com'), false)
+  t.assert.strictEqual(body.data.contact.phone.includes('+39 333 12345'), false)
+})
+
+test('multiple custom directives work together with federation', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+    directive @redact(find: String) on FIELD_DEFINITION
+
+    extend type Query {
+      user: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String @upper
+      email: String @redact(find: "email")
+    }
+  `
+
+  const resolvers = {
+    Query: {
+      user: () => ({ id: '1', name: 'John', email: 'john@example.com' })
+    },
+    User: {
+      __resolveReference: (source) => ({
+        id: source.id,
+        name: 'John',
+        email: 'john@example.com'
+      })
+    }
+  }
+
+  app.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers,
+    schemaTransforms: [upperDirectiveTransformer, redactDirectiveTransformer]
+  })
+
+  await app.ready()
+
+  const query = '{ user { id name email } }'
+  const res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  const body = JSON.parse(res.body)
+
+  t.assert.strictEqual(body.data.user.name, 'JOHN')
+  t.assert.strictEqual(body.data.user.email.includes('john@example.com'), false)
+})
+
+test('federation _entities query not works with custom directive on entity fields when not use federationTrasformer', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String @upper
+      username: String
+    }
+  `
+
+  const users = {
+    1: { id: '1', name: 'John', username: '@john' },
+    2: { id: '2', name: 'Jane', username: '@jane' }
+  }
+
+  const resolvers = {
+    Query: {
+      me: () => users['1']
+    },
+    User: {
+      __resolveReference: (source) => users[source.id]
+    }
+  }
+
+  app.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers,
+    schemaTransforms: [upperDirectiveTransformer]
+  })
+
+  await app.ready()
+
+  const query = `{
+    _entities(representations: [{ __typename: "User", id: "2" }]) {
+      ... on User {
+        id
+        name
+        username
+      }
+    }
+  }`
+  const res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  const body = JSON.parse(res.body)
+
+  t.assert.strictEqual(body.data._entities[0].name, null)
+  t.assert.strictEqual(body.data._entities[0].username, null)
+})
+
+test('federation _entities query works with custom directive on entity fields', async (t) => {
+  const app = Fastify()
+  const schema = `
+    directive @upper on FIELD_DEFINITION
+
+    extend type Query {
+      me: User
+    }
+
+    type User @key(fields: "id") {
+      id: ID!
+      name: String @upper
+      username: String
+    }
+  `
+
+  const users = {
+    1: { id: '1', name: 'John', username: '@john' },
+    2: { id: '2', name: 'Jane', username: '@jane' }
+  }
+
+  const resolvers = {
+    Query: {
+      me: () => users['1']
+    },
+    User: {
+      __resolveReference: (source) => users[source.id]
+    }
+  }
+
+  app.register(GQL, {
+    schema: buildFederationSchema(schema),
+    resolvers,
+    schemaTransforms: federationTrasformer([upperDirectiveTransformer])
+  })
+
+  await app.ready()
+
+  const query = `{
+    _entities(representations: [{ __typename: "User", id: "2" }]) {
+      ... on User {
+        id
+        name
+        username
+      }
+    }
+  }`
+  const res = await app.inject({ method: 'POST', url: '/graphql', body: { query } })
+  const body = JSON.parse(res.body)
+
+  t.assert.strictEqual(body.data._entities[0].name, 'JANE')
+  t.assert.strictEqual(body.data._entities[0].username, '@jane')
+})


### PR DESCRIPTION
This pull request introduces a new utility, `federationSchemaTransformer`, to ensure that `resolveReference` functions on entity types are preserved when applying schema transformations in a federated GraphQL environment. It also updates the plugin and documentation to guide users on when and how to use this utility. The most important changes are grouped below:

**Federation Schema Transformation Utility:**

* Added a new `federationSchemaTransformer` function in `lib/transformFederatedSchema.js` that wraps schema transformers to copy `resolveReference` functions from the original schema onto transformed types, preventing loss of federation entity resolution capability.

* Exported `federationSchemaTransformer` from the main `index.js` module, making it available for external use.

**Plugin Integration:**

* Updated the `mercuriusFederationPlugin` in `lib/plugin.js` to automatically wrap any provided `schemaTransforms` with `federationSchemaTransformer`, ensuring safe usage when custom transformers are passed to the plugin.

**Documentation:**

* Added comprehensive documentation to `README.md` explaining the purpose of `federationSchemaTransformer`, usage scenarios, and the consequences of not using it when building a federated schema manually. Includes example code for both plugin and manual registration approaches.- Export federationSchemaTransformer from index.js with TypeScript definitions
- Add README documentation explaining usage with both mercuriusFederationPlugin (automatic wrapping) and buildFederationSchema + mercurius (manual wrapping)
- Simplify custom directives tests to use buildFederationSchema pattern instead of manually building executable schemas with @graphql-tools