### PR TITLE
Update withCustomDirectives example to use mercuriusFederationPlugin

### DIFF
--- a/examples/withCustomDirectives.js
+++ b/examples/withCustomDirectives.js
@@ -1,11 +1,8 @@
 'use strict'
 
 const Fastify = require('fastify')
-const { mapSchema, getDirective, MapperKind, printSchemaWithDirectives, getResolversFromSchema } = require('@graphql-tools/utils')
-const { mergeResolvers } = require('@graphql-tools/merge')
-const { makeExecutableSchema } = require('@graphql-tools/schema')
-const mercurius = require('mercurius')
-const { buildFederationSchema } = require('../')
+const { mapSchema, getDirective, MapperKind } = require('@graphql-tools/utils')
+const { mercuriusFederationPlugin } = require('../')
 
 const users = {
   1: {
@@ -20,7 +17,6 @@ const users = {
   }
 }
 
-const upperCaseDirectiveTypeDefs = 'directive @upper on FIELD_DEFINITION'
 const uppercaseTransformer = (schema) =>
   mapSchema(schema, {
     [MapperKind.FIELD]: (fieldConfig) => {
@@ -36,14 +32,14 @@ const uppercaseTransformer = (schema) =>
 
 const app = Fastify()
 const schema = `
-  ${upperCaseDirectiveTypeDefs}
+  directive @upper on FIELD_DEFINITION
 
   extend type Query {
     me: User
   }
 
   type User @key(fields: "id") {
-    id: ID! 
+    id: ID!
     name: String @upper
     username: String
   }
@@ -56,21 +52,15 @@ const resolvers = {
     }
   },
   User: {
-    __resolveReference: source => {
+    __resolveReference: (source) => {
       return users[source.id]
     }
   }
 }
 
-const federationSchema = buildFederationSchema(schema)
-
-const executableSchema = makeExecutableSchema({
-  typeDefs: printSchemaWithDirectives(federationSchema),
-  resolvers: mergeResolvers([getResolversFromSchema(federationSchema), resolvers])
-})
-
-app.register(mercurius, {
-  schema: executableSchema,
+app.register(mercuriusFederationPlugin, {
+  schema,
+  resolvers,
   schemaTransforms: [uppercaseTransformer],
   graphiql: true
 })


### PR DESCRIPTION
This pull request simplifies and updates the example for using custom directives with Mercurius Federation. The main changes involve switching to the new `mercuriusFederationPlugin` API and removing unnecessary dependencies and code, making the example more concise and easier to follow.

**Migration to new plugin API:**

* Replaced usage of multiple GraphQL Tools utilities (`makeExecutableSchema`, `mergeResolvers`, `printSchemaWithDirectives`, etc.) and the old `buildFederationSchema` with the new `mercuriusFederationPlugin`, streamlining schema and resolver setup. [[1]](diffhunk://#diff-e6885752ce1cf5791f7b973eb33d5081a1870c8e176cce54be88fee98eada85cL4-R5) [[2]](diffhunk://#diff-e6885752ce1cf5791f7b973eb33d5081a1870c8e176cce54be88fee98eada85cL59-R63)

**Code simplification and cleanup:**

* Removed the separate `upperCaseDirectiveTypeDefs` variable and inlined the directive definition directly into the schema string, reducing indirection. [[1]](diffhunk://#diff-e6885752ce1cf5791f7b973eb33d5081a1870c8e176cce54be88fee98eada85cL23) [[2]](diffhunk://#diff-e6885752ce1cf5791f7b973eb33d5081a1870c8e176cce54be88fee98eada85cL39-R35)
* Minor formatting and consistency update to the `__resolveReference` resolver function.